### PR TITLE
Heartstones as fuel

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,14 +15,12 @@ endmacro()
 
 macro(find_commonlib_path)
 	if (CommonLibName AND NOT ${CommonLibName} STREQUAL "")
-		# Check path
-		set_from_environment(${CommonLibName}Path)
-		set(CommonLibPath ${${CommonLibName}Path})
+		find_path(CommonLibPath
+		include/REL/Relocation.h
+		PATHS extern/${CommonLibName})
 		if (${CommonLibPath} STREQUAL "CommonLibPath-NOTFOUND")
-			#Check extern
-			find_path(CommonLibPath
-			include/REL/Relocation.h
-			PATHS extern/${CommonLibName})
+			set_from_environment(${CommonLibName}Path)
+			set(CommonLibPath ${${CommonLibName}Path})
 		endif()
 	endif()
 endmacro()
@@ -188,10 +186,10 @@ endif ()
 
 # ---- Post build ----
 if(DEFINED ENV{SKYRIM_MODS_FOLDER} AND IS_DIRECTORY "$ENV{SKYRIM_MODS_FOLDER}")
-	if(BUILD_SKYRIMAE)
-		set(OUTPUT_FOLDER "$ENV{SKYRIM_MODS_FOLDER}/${PROJECT_NAME}")
-	else() 
+	if(BUILD_TEST)
 		set(OUTPUT_FOLDER "$ENV{SKYRIM_MODS_FOLDER}/${PROJECT_NAME} - Test")
+	else() 
+		set(OUTPUT_FOLDER "$ENV{SKYRIM_MODS_FOLDER}/${PROJECT_NAME}")
 	endif()
 endif()
 

--- a/cmake/sourcelist.cmake
+++ b/cmake/sourcelist.cmake
@@ -17,6 +17,7 @@ set(sources ${sources}
 	src/Hooks/VFX.cpp
 	src/Papyrus/AmmoEnchanting.cpp
 	src/RE/BSResource.cpp
+	src/RE/BaseExtraList.cpp
 	src/SKSEPlugin/SKSEPlugin.cpp
 	src/Serialization/Serialization.cpp
 	src/Settings/GlobalSettings.cpp

--- a/src/Events/ActivationListener.cpp
+++ b/src/Events/ActivationListener.cpp
@@ -122,7 +122,6 @@ namespace ActivationListener
 			enchant->formFlags |= RE::TESForm::RecordFlags::kKnown;
 			enchant->AddChange(RE::TESForm::ChangeFlags::kFlags);
 		}
-		_loggerInfo("Player is in staff enchanter");
 		continueEvent;
 	}
 

--- a/src/Hooks/FilterFlags.cpp
+++ b/src/Hooks/FilterFlags.cpp
@@ -605,13 +605,16 @@ namespace Hooks
 				}
 				return FilterFlag::None;
 			}
-			else if (const auto soulGem = object->As<RE::TESSoulGem>()) {
-				if (a_entry->GetSoulLevel() == RE::SOUL_LEVEL::kNone) {
-					return FilterFlag::None;
-				}
-				else {
+			else if (const auto entryObj = a_entry->GetObject()) {
+				if (entryObj->HasKeywordByEditorID("STEN_StaffFuel")) {
+					if (a_entry->GetSoulLevel() == RE::SOUL_LEVEL::kNone) {
+						auto* newList = new RE::ExtraDataList();
+						newList->Add(new RE::ExtraSoul(RE::SOUL_LEVEL::kGrand));
+						a_entry->AddExtraList(newList);
+					}
 					return FilterFlag::SoulGem;
 				}
+				return FilterFlag::None;
 			}
 			else {
 				return FilterFlag::None;
@@ -646,7 +649,7 @@ namespace Hooks
 			else {
 				return FilterFlag::DisenchantWeapon;
 			}
-		}
+		} 
 		else if (const auto ammo = object->As<RE::TESAmmo>()) {
 			const auto globalSettings = Settings::GlobalSettings::GetSingleton();
 			if (!globalSettings->AmmoEnchantingEnabled() ||

--- a/src/Hooks/FilterFlags.h
+++ b/src/Hooks/FilterFlags.h
@@ -40,8 +40,10 @@ namespace Hooks
 		// When selecting an enchantment without an item, identify Ammo form type
 		static void ItemPreviewPatch();
 
-		//Allows for staff enchantments to show in the menu. The menu filters out non-self const // touch ff enchantments by default.
+		// Allows for staff enchantments to show in the menu. The menu filters out non-self const // touch ff enchantments by default.
 		static void EnchantmentEntryPatch();
+		// Allows for there to be an item card when using alternate staff fuel.
+		static void ItemCardPatch();
 
 		static void PushBack(void* a_arg1, Menu::EnchantmentEntry* a_entry);
 
@@ -53,6 +55,11 @@ namespace Hooks
 
 		static RE::FormType GetFormTypeFromEffectFlag(std::uint32_t a_flag);
 
+		static void SetItemCardInfo(
+			RE::CraftingSubMenus::EnchantConstructMenu::ItemChangeEntry* a_categories,
+			RE::CraftingSubMenus::EnchantConstructMenu* a_menu);
+
 		inline static REL::Relocation<decltype(&PushBack)> _PushBack;
+		inline static REL::Relocation<decltype(&SetItemCardInfo)> _SetItemCardInfo;
 	};
 }

--- a/src/Hooks/SkyUI.cpp
+++ b/src/Hooks/SkyUI.cpp
@@ -208,6 +208,11 @@ namespace Hooks
 				a_dataContainer->SetMember("magicType", baseEffect->data.resistVariable);
 			}
 		} break;
+
+		case FilterFlag::SoulGem:
+		{
+
+		} break;
 		}
 	}
 }

--- a/src/RE/BaseExtraList.cpp
+++ b/src/RE/BaseExtraList.cpp
@@ -1,0 +1,6 @@
+#include "RE/E/ExtraDataList.h"
+
+namespace RE
+{
+	BaseExtraList::~BaseExtraList() = default;
+}

--- a/src/SKSEPlugin/SKSEPlugin.cpp
+++ b/src/SKSEPlugin/SKSEPlugin.cpp
@@ -54,6 +54,22 @@ namespace
 			}
 		}
 	}
+
+	void HandleSoulGemFuel()
+	{
+		auto* fuelKeyword = RE::TESForm::LookupByEditorID<RE::BGSKeyword>("STEN_StaffFuel"sv);
+		if (!fuelKeyword) {
+			_loggerError(
+				"Warning: Failed to find STEN_StaffFuel. Ensure that the plugin is loaded.");
+			return;
+		}
+
+		auto* dataHandler = RE::TESDataHandler::GetSingleton();
+		auto& soulGemArray = dataHandler->GetFormArray<RE::TESSoulGem>();
+		for (auto* soulGem : soulGemArray) {
+			soulGem->AddKeyword(fuelKeyword);
+		}
+	}
 }
 
 void MessageHandler(SKSE::MessagingInterface::Message* a_message)
@@ -62,6 +78,9 @@ void MessageHandler(SKSE::MessagingInterface::Message* a_message)
 	case SKSE::MessagingInterface::kDataLoaded:
 		if (Settings::INISettings::GetSingleton()->bAdjustStaffEnchanters) {
 			HandleEnchantingTables();
+		}
+		if (Settings::INISettings::GetSingleton()->bUseSoulGemsForStaves) {
+			HandleSoulGemFuel();
 		}
 		ActivationListener::EnchantingTable::GetSingleton()->RegisterListener();
 		break;
@@ -89,7 +108,7 @@ extern "C" DLLEXPORT bool SKSEAPI SKSEPlugin_Load(const SKSE::LoadInterface* a_s
 	_loggerInfo("Plugin Version: {}.", Version::VERSION);
 	_loggerInfo("-------------------------------------------------------------------------------------");
 	SKSE::Init(a_skse);
-	SKSE::AllocTrampoline(287);
+	SKSE::AllocTrampoline(301);
 
 	_loggerInfo("Reading settings...");
 	Settings::INISettings::GetSingleton()->LoadSettings();

--- a/src/Settings/INISettings.cpp
+++ b/src/Settings/INISettings.cpp
@@ -23,6 +23,9 @@ namespace Settings
 		bEnableMultiEnchantments = static_cast<bool>(
 			ini.GetBoolValue("StaffEnchanting", "bEnableMultiEnchantments", false));
 
+		bUseSoulGemsForStaves = static_cast<bool>(
+			ini.GetBoolValue("StaffEnchanting", "bUseSoulGemsForStaves", false));
+
 		fStaffChargeMult = static_cast<float>(
 			ini.GetDoubleValue("StaffEnchanting", "fStaffChargeMult", 10.0));
 

--- a/src/Settings/INISettings.h
+++ b/src/Settings/INISettings.h
@@ -18,6 +18,7 @@ namespace Settings
 		bool bAdjustStaffEnchanters;
 		bool bStaffChargeEnabled;
 		bool bEnableMultiEnchantments;
+		bool bUseSoulGemsForStaves;
 		float fStaffChargeMult;
 		float fAmmoChargeMult;
 		float fAmmoEffectCostMult;


### PR DESCRIPTION
Rudimentary support for using alternate soul gems (such as Heart Stones) in staff enchanting stations.